### PR TITLE
return `default` if the context doesn't have a namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.1.4
+- Use `default` if there's no namespace defined in the context
+
 ## 0.1.3
 - On `Okteto: Up` failure, automatically open the terminal to show the user what went wrong.
 - Set the `cwd` of the terminal to that of the okteto manifest.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ function getManifestOrAsk(state: vscode.Memento): Promise<string> {
 
 function down(manifestPath: string, state: vscode.Memento) {
     const ktx = kubernetes.getCurrentContext(); 
-    if (!ktx.namespace) {
+    if (!ktx) {
         vscode.window.showErrorMessage("Couldn't detect your current Kubernetes context.");
         return;
     }
@@ -144,7 +144,7 @@ function up(state: vscode.Memento) {
         console.log(`user selected: ${manifestPath}`);
         manifest.getName(manifestPath).then((name) =>{
             const ktx = kubernetes.getCurrentContext();
-            if (!ktx.namespace) {
+            if (!ktx) {
                 vscode.window.showErrorMessage("Couldn't detect your current Kubernetes context.");
                 return;
             } 

--- a/src/kubernetes.ts
+++ b/src/kubernetes.ts
@@ -1,7 +1,7 @@
 import * as k8s from '@kubernetes/client-node';
 
 
-export function getCurrentContext(): {context: string, namespace:string} {
+export function getCurrentContext(): {context: string, namespace:string} | undefined {
     try{
         const kc = new k8s.KubeConfig();
         kc.loadFromDefault();
@@ -11,13 +11,10 @@ export function getCurrentContext(): {context: string, namespace:string} {
         const ns =  ctx ? ctx.namespace : '';
         return {
             context: current,
-            namespace: ns ? ns : '',
-        }
+            namespace: ns ? ns : 'default',
+        };
     }catch(err) {
         console.error(`failed to get the context: ${err}`);
-        return {
-            context: '',
-            namespace: ''
-        }
+        return undefined;
     }
 }


### PR DESCRIPTION
fixes #26 