### PR TITLE
install okteto in $HOME/.okteto-vscode  to avoid permission issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.12
+- Change dependency install location to `$HOME/.okteto` on OSX/Linux and `$HOME\AppData\Local\Programs`.
+- Download the binaries directly from Github.
+
 ## 0.1.11
 - `Git Bash mode` setting.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"gke",
 		"eks"
 	],
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"icon": "media/icon.png",
 	"author": {
 		"name": "Ramiro Berrelleza",

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -80,25 +80,23 @@ async function getVersion(binary: string): Promise<string | undefined> {
 
 export async function install() {
   let source = '';
-  let destination = '';
   let chmod = true;
 
   switch(os.platform()){
     case 'win32':
       source = 'https://downloads.okteto.com/cli/okteto-Windows-x86_64';
-      destination = getWindowsInstallPath();
       chmod = false;
       break;
     case 'darwin':
       source = 'https://downloads.okteto.com/cli/okteto-Darwin-x86_64';
-      destination = '/usr/local/bin/okteto';
       break;
     default:
         source = 'https://downloads.okteto.com/cli/okteto-Linux-x86_64';
-        destination = '/usr/local/bin/okteto';
   }
 
   try {
+    let destination = getInstallPath();
+    await promises.mkdir(path.dirname(destination), 0o700);
     await downloadFile(source, destination);
     if (!chmod) {
       return;
@@ -109,7 +107,7 @@ export async function install() {
       throw new Error(`failed to set exec permissions; ${r.stdout}`);  
     }
   } catch(err) {
-    throw new Error(`failed to download ${source}: ${err.message}`);  
+    throw new Error(`failed to install okteto: ${err.message}`);  
   }
 }
 
@@ -122,12 +120,10 @@ function downloadFile(source: string, destination: string) {
       return;
     });
 
-  st.on('finish', () => {
+    st.on('finish', () => {
       resolve();
       return;
     });
-    
-    
   });
 }
 
@@ -237,15 +233,15 @@ function getBinary(): string {
     return binary;
   }
 
-  if (os.platform() === 'win32') {
-    return getWindowsInstallPath();
-  }
-  
-  return 'okteto';
+  return getInstallPath();
 }
 
-function getWindowsInstallPath(): string {
-  return path.join(home, "AppData", "Local", "Programs", "okteto.exe");
+function getInstallPath(): string {
+  if (os.platform() === 'win32') {
+    return path.join(home, "AppData", "Local", "Programs", "okteto.exe");
+  }
+
+  return path.join(home, ".okteto", "okteto");
 }
 
 function disposeTerminal(){

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -84,19 +84,24 @@ export async function install() {
 
   switch(os.platform()){
     case 'win32':
-      source = 'https://downloads.okteto.com/cli/okteto-Windows-x86_64';
+      source = 'https://github.com/okteto/okteto/releases/latest/download/okteto-Windows-x86_64';
       chmod = false;
       break;
     case 'darwin':
-      source = 'https://downloads.okteto.com/cli/okteto-Darwin-x86_64';
+      source = 'https://github.com/okteto/okteto/releases/latest/download/okteto-Darwin-x86_64';
       break;
     default:
-        source = 'https://downloads.okteto.com/cli/okteto-Linux-x86_64';
+        source = 'https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-x86_64';
+  }
+  
+  let destination = getInstallPath();
+  try {
+    await promises.mkdir(path.dirname(destination), 0o700);
+  } catch(err) {
+    console.log(`failed to create dir: ${err.message}`);
   }
 
-  try {
-    let destination = getInstallPath();
-    await promises.mkdir(path.dirname(destination), 0o700);
+  try {  
     await downloadFile(source, destination);
     if (!chmod) {
       return;
@@ -241,7 +246,7 @@ function getInstallPath(): string {
     return path.join(home, "AppData", "Local", "Programs", "okteto.exe");
   }
 
-  return path.join(home, ".okteto", "okteto");
+  return path.join(home, '.okteto-vscode', 'okteto');
 }
 
 function disposeTerminal(){


### PR DESCRIPTION
I've seen some errors in our telemetry due to vscode not having permissions to write in `/usr/local/bin` (which makes sense, because the default owner of that folder is root). I'm moving the install path to `$HOME/.okteto-vscode` on linux and unix, since that's owned by the user. 

The downside is that if the user already has okteto installed, it'll be installed again in a different path. I think it's a fair tradeoff to prevent directory ownership issues, but what do you think?