### PR TITLE
Open multiple project in single workspace.

### DIFF
--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -144,7 +144,7 @@ export function up(manifest: string, namespace: string, name: string, port: numb
   disposeTerminal();
   cleanState(namespace, name);
   const term = vscode.window.createTerminal({
-    name: terminalName,
+    name: terminalName+"-"+port,
     hideFromUser: false,
     cwd: path.dirname(manifest),
     env: {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -4,7 +4,7 @@ import * as gp from 'get-port';
 import * as net from 'net';
 
 export function getPort(): Promise<number> {
-    return gp({port: 22100});
+    return gp({host:'127.0.0.1', port: 22100});
 }
 
 export function isReady(port: number): Promise<Boolean> {


### PR DESCRIPTION
- Add port as terminal name to prevent previously opened terminal (with same name) be closed, so that we can keep multiple Okteto session running in a single workspace with multiple project.
- According to the issue #sindresorhus/get-port/issues/31, `gp()` should add `host:` option to get it work on macOS.