### PR TITLE
Open multiple project in single workspace.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,7 @@ async function upCommand(selectedManifestUri: vscode.Uri) {
     } catch (err) {
         reporter.track(events.manifestLoadFailed);
         reporter.captureError(`load manifest failed: ${err.message}`, err);
-        return onOktetoFailed('', `Okteto: Up failed to load your Okteto manifest: ${err.message}`);
+        return onOktetoFailed(`Okteto: Up failed to load your Okteto manifest: ${err.message}`);
     }
 
     const kubeconfig = kubernetes.getKubeconfig();
@@ -114,7 +114,7 @@ async function upCommand(selectedManifestUri: vscode.Uri) {
     } catch (err) {
         reporter.track(events.sshPortFailed);
         reporter.captureError(`ssh.getPort failed: ${err.message}`, err);
-        return onOktetoFailed(m.namespace, `Okteto: Up failed to find an available port: ${err}`);
+        return onOktetoFailed(`Okteto: Up failed to find an available port: ${err}`, m.namespace);
     }
 
     okteto.up(manifestPath, m.namespace, m.name, port, kubeconfig);
@@ -124,7 +124,7 @@ async function upCommand(selectedManifestUri: vscode.Uri) {
         await waitForUp(m.namespace, m.name, port);
     } catch(err) {
         reporter.captureError(`okteto up failed: ${err.message}`, err);
-        return onOktetoFailed(m.namespace, err.message);
+        return onOktetoFailed(err.message, m.namespace);
     }
 
     await finalizeUp(m.namespace,m.name, m.workdir);
@@ -207,7 +207,7 @@ async function finalizeUp(namespace: string, name: string, workdir: string) {
     } catch (err) {
         reporter.captureError(`opensshremotes.openEmptyWindow failed: ${err.message}`, err);
         reporter.track(events.sshHostSelectionFailed);
-        return onOktetoFailed(namespace, `Okteto: Up failed to open the host selector: ${err.message}`);
+        return onOktetoFailed(`Okteto: Up failed to open the host selector: ${err.message}`, namespace);
     }
 }
 
@@ -235,7 +235,7 @@ async function downCommand() {
     } catch (err) {
         reporter.track(events.manifestLoadFailed);
         reporter.captureError(`load manifest failed: ${err.message}`, err);
-        return onOktetoFailed('', `Okteto: Down failed to load your Okteto manifest: ${err.message}`);
+        return onOktetoFailed(`Okteto: Down failed to load your Okteto manifest: ${err.message}`);
     }
 
     const kubeconfig = kubernetes.getKubeconfig();
@@ -326,9 +326,11 @@ async function createCmd(){
     }
 }
 
-function onOktetoFailed(namespace: string, message: string) {
+function onOktetoFailed(message: string, namespace: string | null = null) {
     vscode.window.showErrorMessage(message);
-    okteto.showTerminal(namespace);
+    if (namespace) {
+        okteto.showTerminal(namespace);
+    }
 }
 
 async function showManifestPicker() : Promise<vscode.Uri | undefined> {
@@ -354,7 +356,7 @@ Please run the 'Okteto: Create Manifest' command to create it and then try again
 }
 
 async function showActiveManifestPicker() : Promise<vscode.Uri | undefined> {
-    let items : any[] = [];
+    let items: any[] = [];
     activeManifest.forEach((file, manifest) => {
         items.push({
             label: manifest,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -356,7 +356,7 @@ Please run the 'Okteto: Create Manifest' command to create it and then try again
 }
 
 async function showActiveManifestPicker() : Promise<vscode.Uri | undefined> {
-    let items: any[] = [];
+    const items: any[] = [];
     activeManifest.forEach((file, manifest) => {
         items.push({
             label: manifest,

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -342,7 +342,7 @@ function getInstallPath(): string {
   return path.join(os.homedir(), '.okteto-vscode', 'okteto');
 }
 
-function disposeTerminal(namespace : string){
+function disposeTerminal(namespace: string){
   vscode.window.terminals.forEach((t) => {
     if (t.name === `${terminalName}-${namespace}`) {
       t.dispose();
@@ -350,7 +350,7 @@ function disposeTerminal(namespace : string){
   });
 }
 
-export function showTerminal(namespace : string){
+export function showTerminal(namespace: string){
   vscode.window.terminals.forEach((t) => {
     if (t.name === `${terminalName}-${namespace}`) {
       t.show();

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -144,7 +144,7 @@ export function up(manifest: string, namespace: string, name: string, port: numb
   disposeTerminal();
   cleanState(namespace, name);
   const term = vscode.window.createTerminal({
-    name: terminalName,
+    name: terminalName+"-"+port,
     hideFromUser: false,
     cwd: path.dirname(manifest),
     env: {

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -140,13 +140,13 @@ export async function install() {
 
 export function up(manifest: string, namespace: string, name: string, port: number, kubeconfig: string) {
   console.log(`okteto up ${manifest}`);
-  if (isActive.has(`${terminalName}-${namespace}`) && isActive.get(`${terminalName}-${namespace}`)) {
-    disposeTerminal(namespace);
+  if (isActive.has(`${terminalName}-${namespace}-${name}`) && isActive.get(`${terminalName}-${namespace}-${name}`)) {
+    disposeTerminal(`${namespace}-${name}`);
   }
-  isActive.set(`${terminalName}-${namespace}`, false);
+  isActive.set(`${terminalName}-${namespace}-${name}`, false);
   cleanState(namespace, name);
   const term = vscode.window.createTerminal({
-    name: `${terminalName}-${namespace}`,
+    name: `${terminalName}-${namespace}-${name}`,
     hideFromUser: false,
     cwd: path.dirname(manifest),
     env: {
@@ -164,7 +164,7 @@ export function up(manifest: string, namespace: string, name: string, port: numb
     manifest = paths.toGitBash(manifest);
   }
 
-  isActive.set(`${terminalName}-${namespace}`, true);
+  isActive.set(`${terminalName}-${namespace}-${name}`, true);
   let cmd = `${binary} up -f '${manifest}' --remote '${port}'`;
 
   const config = vscode.workspace.getConfiguration('okteto');
@@ -177,9 +177,9 @@ export function up(manifest: string, namespace: string, name: string, port: numb
   term.sendText(cmd, true);
 }
 
-export async function down(manifest: string, namespace: string, kubeconfig: string) {
-  isActive.set(`${terminalName}-${namespace}`, false);
-  disposeTerminal(namespace);
+export async function down(manifest: string, namespace: string, name: string, kubeconfig: string) {
+  isActive.set(`${terminalName}-${namespace}-${name}`, false);
+  disposeTerminal(`${namespace}-${name}`);
   
   const r =  execa(getBinary(), ['down', '--file', `${manifest}`, '--namespace', `${namespace}`], {
     env: {
@@ -293,7 +293,7 @@ function splitStateError(state: string): {state: string, message: string} {
 export async function notifyIfFailed(namespace: string, name:string, callback: (n: string, m: string) => void){
   const id = setInterval(async () => {
     const c = await getState(namespace, name);
-    if (!isActive.has(`${terminalName}-${namespace}`) || !isActive.get(`${terminalName}-${namespace}`)) {
+    if (!isActive.has(`${terminalName}-${namespace}-${name}`) || !isActive.get(`${terminalName}-${namespace}-${name}`)) {
       clearInterval(id);
       return;
     }
@@ -302,9 +302,9 @@ export async function notifyIfFailed(namespace: string, name:string, callback: (
       console.error(`okteto up failed: ${c.message}`);
       clearInterval(id);
       if (c.message) {
-        callback(namespace, `Okteto: Up command failed: ${c.message}`);
+        callback(`${namespace}-${name}`, `Okteto: Up command failed: ${c.message}`);
       } else {
-        callback(namespace, `Okteto: Up command failed`);
+        callback(`${namespace}-${name}`, `Okteto: Up command failed`);
       }
     }
 
@@ -342,17 +342,17 @@ function getInstallPath(): string {
   return path.join(os.homedir(), '.okteto-vscode', 'okteto');
 }
 
-function disposeTerminal(namespace: string){
+function disposeTerminal(terminalNameSuffix: string){
   vscode.window.terminals.forEach((t) => {
-    if (t.name === `${terminalName}-${namespace}`) {
+    if (t.name === `${terminalName}-${terminalNameSuffix}`) {
       t.dispose();
     }
   });
 }
 
-export function showTerminal(namespace: string){
+export function showTerminal(terminalNameSuffix: string){
   vscode.window.terminals.forEach((t) => {
-    if (t.name === `${terminalName}-${namespace}`) {
+    if (t.name === `${terminalName}-${terminalNameSuffix}`) {
       t.show();
     }
   });

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -32,7 +32,7 @@ export const state = {
   failed: 'failed',
 };
 
-var isActive = new Map();
+const isActive = new Map();
 
 export async function needsInstall(): Promise<{install: boolean, upgrade: boolean}>{
   const binary = getBinary();

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -4,7 +4,7 @@ import * as gp from 'get-port';
 import * as net from 'net';
 
 export function getPort(): Promise<number> {
-    return gp({port: 22100});
+    return gp({host:'127.0.0.1', port: 22100});
 }
 
 export function isReady(port: number): Promise<Boolean> {


### PR DESCRIPTION
- Add `host:` option to get random available port correctly (issue: sindresorhus/get-port/issues/31).
- Add namespace as part of terminal name for supporting multiple terminal.
- If these is some active manifest, select an active manifests to deactivate.
- Show the corresponding terminal if error occured.