### PR TITLE
Fix UP call arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         },
         "okteto.upArgs": {
           "type": "string",
-          "default": "--loglevel=warn",
+          "default": "--log-level=warn",
           "description": "Extra arguments to pass to okteto up. You can use it to get debug logs, force a build before the up command, etc..."
         }
       }


### PR DESCRIPTION
The UP command fails due to the argument `--loglevel` which is missing a hyphen: `--log-level` 