### PR TITLE
fix: autogenerate stignore on okteto up

### DIFF
--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -199,6 +199,7 @@ export function up(manifest: string, namespace: string, name: string, port: numb
     cwd: path.dirname(manifest),
     env: {
       "OKTETO_ORIGIN":"vscode",
+      "OKTETO_AUTOGENERATE_STIGNORE": "true",
     },
     message: "This terminal will be automatically closed when you run the okteto down command. Happy coding!",
     iconPath: new vscode.ThemeIcon('server-process')


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes https://github.com/okteto/okteto/issues/2745

## Proposed changes
- Adds the env var `OKTETO_AUTOGENERATE_STIGNORE` which will skip the stignore questions and will create the stignore file on the fly without asking the user any question