### PR TITLE
Support docker-compose directly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,22 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "args": [
+                "-r",  
+                "ts-node/register",
+                "${workspaceFolder}/src/test/suite/*.test.ts"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        
+        {
             "type": "extensionHost",
             "request": "launch",
             "name": "Launch Extension",
@@ -19,7 +35,8 @@
             "env": {
                 "ENV": "dev"
             }
-        }
+        },
+        
 
     ],
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,9 +219,9 @@ async function waitForUp(namespace: string, name: string, port: number) {
 
 async function waitForFinalState(namespace: string, name:string, progress: vscode.Progress<{message?: string | undefined; increment?: number | undefined}>): Promise<{result: boolean, message: string}> {
     const config = vscode.workspace.getConfiguration('okteto');
-    let upTimeout = 100;
+    let upTimeout = 1000;
     if (config) {
-        upTimeout = config.get<number>('timeout') || 100;
+        upTimeout = config.get<number>('timeout') || 1000;
     }
     
     const seen = new Map<string, boolean>();

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -5,11 +5,10 @@ export class Manifest {
     constructor(public name: string, public namespace: string, public workdir: string, public port: number) {}
 }
 
-function isDockerCompose(manifest: any): boolean {
+export function isDockerCompose(manifest: any): boolean {
     if (manifest.services) {
         const s = manifest.services;
         for (let $_ in s){
-            
             return true;
         }
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -54,7 +54,7 @@ function isOktetoV2(manifest: any): boolean {
 }
 
 function isOktetoV1(manifest: any): boolean {
-    if (manifest.name && !manifest.dev) {
+    if (manifest.name) {
         return true;
     }
 

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -3,8 +3,14 @@
 import gp from 'get-port';
 import * as net from 'net';
 
+var nextPort = 22100;
+
 export function getPort(): Promise<number> {
-    return gp({host:'127.0.0.1', port: 22100});
+    const port = nextPort;
+    
+    // poorman's port collision avoidance
+    nextPort++
+    return gp({host:'127.0.0.1', port: port});
 }
 
 export function isReady(port: number): Promise<Boolean> {

--- a/src/test/suite/artifacts/docker-compose-invalid.yaml
+++ b/src/test/suite/artifacts/docker-compose-invalid.yaml
@@ -1,0 +1,7 @@
+services:
+ redis:
+    image: redis
+    ports:
+    - 6379
+ vote:
+    image: okteto.dev/vote

--- a/src/test/suite/artifacts/docker-compose.yaml
+++ b/src/test/suite/artifacts/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+ redis:
+    image: redis
+    ports:
+    - 6379
+ vote:
+    image: okteto.dev/vote
+    volumes:
+      - vote:/usr/src/app

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -32,6 +32,30 @@ describe('parseManifest', () => {
     expect(result[1].namespace).to.equal(undefined);
   });
 
+  it('parse docker-compose', () => {
+    const data = fs.readFileSync('src/test/suite/artifacts/docker-compose.yaml', {encoding: 'utf8'});
+    const parsed = yaml.parseDocument(data);
+    const result = manifest.parseManifest(parsed);
+    expect(result.length).to.equal(1);
+    expect(result[0].workdir).to.equal('/usr/src/app');
+    expect(result[0].name).to.equal('vote');
+    expect(result[0].port).to.equal(0);
+  });
+
+  it('invalid docker-compose fails validation', () => {
+    const data = fs.readFileSync('src/test/suite/artifacts/docker-compose-invalid.yaml', {encoding: 'utf8'});
+    const parsed = yaml.parseDocument(data);
+    const result = manifest.isDockerCompose(parsed);
+    expect(result).to.equal(false);
+  });
+
+  it('valid docker-compose pases validation', () => {
+    const data = fs.readFileSync('src/test/suite/artifacts/docker-compose.yaml', {encoding: 'utf8'});
+    const parsed = yaml.parseDocument(data);
+    const result = manifest.isDockerCompose(parsed);
+    expect(result).to.equal(false);
+  });
+
   it('parse legacy manifest', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/legacy-manifest.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -11,6 +11,7 @@ describe('parseManifest', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/simple-manifest.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
+    expect(result).to.not.equal(undefined);
     expect(result.length).to.equal(2);
     expect(result[0].workdir).to.equal('/usr/src/app');
     expect(result[1].workdir).to.equal('/usr/src/frontend');
@@ -45,15 +46,15 @@ describe('parseManifest', () => {
   it('invalid docker-compose fails validation', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/docker-compose-invalid.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
-    const result = manifest.isDockerCompose(parsed);
-    expect(result).to.equal(false);
+    const result = manifest.parseManifest(parsed);
+    expect(result.length).to.equal(0);
   });
 
   it('valid docker-compose pases validation', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/docker-compose.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
-    const result = manifest.isDockerCompose(parsed);
-    expect(result).to.equal(false);
+    const result = manifest.parseManifest(parsed);
+    expect(result.length).to.equal(1);
   });
 
   it('parse legacy manifest', () => {


### PR DESCRIPTION
With this change, the extension will be able to directly support docker-compose. It is using the following assumptions:
1. There is at least one service that has at least one volume defined with the format `local: /remote/path`
2. The user will pick the service

@pchico83 is this the same thing that the CLI does? 