### PR TITLE
Fix the issue that telemetry can't be disabled.

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -49,8 +49,9 @@ export class Reporter {
         this.machineId = machineId;
         
         const config = vscode.workspace.getConfiguration('okteto');
-        if (config) {
-            this.enabled = config.get<boolean>('telemetry') || true;
+        const telemetry = config.get<boolean>('telemetry');
+        if (config && telemetry != undefined) {
+            this.enabled = telemetry;
         }
 
         if (oktetoId) {


### PR DESCRIPTION
Fix the issue that telemetry can't be disabled, as mentioned in #230. As config.get<boolean>('telemetry') has type boolean | undefined.