### PR TITLE
upgrade to cli 3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
       with:
         node-version: 16
     - name: npm install, build, and test
@@ -22,7 +23,7 @@ jobs:
         mv remote-kubernetes-*.vsix artifacts/
       env:
         CI: "true"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with: 
         name: artifacts
         path: artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get tag
       id: vars
       run: echo "release_tag=$(echo ${GITHUB_REF:11})" > $GITHUB_ENV
-    - name: Use Node.js 16
-      uses: actions/setup-node@v3
+    - name: Use Node.js 22
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 22
     - run: npm ci
     - run: npm run test
     - name: publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Updated minimum required Okteto CLI version to 3.0.0
 - Remove "okteto create" command since the CLI doesn't support it anymore
 - Removed support for Okteto Stacks or Okteto Manifest 1.0 since they have been fully deprecated
+- Namespace is no longer read from the manifest; instead, you need to set it via the `context` command
 - Updated dependencies
 
 ## 0.4.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.5.0
+- Updated minimum required Okteto CLI version to 3.0.0
+- Remove "okteto create" command since the CLI doesn't support it anymore
+- Removed support for Okteto Stacks or Okteto Manifest 1.0 since they have been fully deprecated
+- Updated dependencies
+
 ## 0.4.15
 - Updated minimum required Okteto CLI version to 2.29.3
 - Updated dependencies  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.5.0
 - Updated minimum required Okteto CLI version to 3.0.0
-- Remove "okteto create" command since the CLI doesn't support it anymore
+- Added a command to run tests using "Okteto Test"
+- Removed "okteto create" command since the CLI doesn't support it anymore
 - Removed support for Okteto Stacks or Okteto Manifest 1.0 since they have been fully deprecated
 - Namespace is no longer read from the manifest; instead, you need to set it via the `context` command
 - Updated dependencies

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Kubernetes, Okteto and VS Code make a great development environment because you 
 - Eliminate integration issues by developing the same way code runs in production.
 - Keep using your favorite tools.
 - Forget about building images or redeploying containers to test your changes in Kubernetes.
+- Run your tests directly in Kubernetes
 
 The extension starts a development environment in your Kubernetes cluster by using https://github.com/okteto/okteto. Once the environment is ready, the extension prompts you to open it directly in VS Code using the [Visual Studio Code Remote - SSH](https://code.visualstudio.com/docs/remote/ssh) extension.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remote-kubernetes",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remote-kubernetes",
-      "version": "0.4.15",
+      "version": "0.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sentry/cli": "^2.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,12 +40,12 @@
         "glob": "^7.1.7",
         "markdown-it": ">=12.3.2",
         "mocha": "^9.1.1",
-        "ts-loader": "^9.2.5",
+        "ts-loader": "^9.5.1",
         "ts-node": "^10.2.1",
         "typescript": "^5.2.2",
         "vscode-test": "^1.6.1",
-        "webpack": "^5.75.0",
-        "webpack-cli": "^4.8.0"
+        "webpack": "^5.96.1",
+        "webpack-cli": "^5.1.4"
       },
       "engines": {
         "vscode": "^1.80.0"
@@ -889,10 +889,11 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -1377,34 +1378,45 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
-      "dependencies": {
-        "envinfo": "^7.7.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
@@ -1425,23 +1437,15 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -1690,9 +1694,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -1708,11 +1712,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1871,9 +1876,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001646",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
-      "integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw==",
+      "version": "1.0.30001676",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
+      "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
       "dev": true,
       "funding": [
         {
@@ -1888,7 +1893,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -2489,10 +2495,11 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
-      "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==",
-      "dev": true
+      "version": "1.5.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz",
+      "integrity": "sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2536,10 +2543,11 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -2575,10 +2583,11 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3586,12 +3595,13 @@
       "optional": true
     },
     "node_modules/interpret": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/is-binary-path": {
@@ -3607,10 +3617,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -4634,7 +4645,8 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4906,7 +4918,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "2.0.0",
@@ -4949,10 +4962,11 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5232,15 +5246,16 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/require-directory": {
@@ -5257,6 +5272,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -5707,6 +5723,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6160,9 +6177,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "funding": [
         {
@@ -6178,9 +6195,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -6313,21 +6331,21 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.5",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
         "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -6360,42 +6378,41 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
-        "commander": "^7.0.0",
+        "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x"
+        "webpack": "5.x.x"
       },
       "peerDependenciesMeta": {
         "@webpack-cli/generators": {
-          "optional": true
-        },
-        "@webpack-cli/migrate": {
           "optional": true
         },
         "webpack-bundle-analyzer": {
@@ -6407,12 +6424,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=14"
       }
     },
     "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gke",
     "eks"
   ],
-  "version": "0.4.15",
+  "version": "0.5.0",
   "icon": "media/icon.png",
   "author": {
     "name": "Ramiro Berrelleza",
@@ -39,11 +39,6 @@
   "main": "./dist/extension",
   "contributes": {
     "commands": [
-      {
-        "command": "okteto.create",
-        "title": "Okteto: Create Manifest",
-        "enablement": "workspaceFolderCount != 0"
-      },
       {
         "command": "okteto.down",
         "title": "Okteto: Down"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
       {
         "command": "okteto.destroy",
         "title": "Okteto: Destroy your development environment"
+      },
+      {
+        "command": "okteto.test",
+        "title": "Okteto: Run your tests on your development environment"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -141,12 +141,12 @@
     "glob": "^7.1.7",
     "markdown-it": ">=12.3.2",
     "mocha": "^9.1.1",
-    "ts-loader": "^9.2.5",
+    "ts-loader": "^9.5.1",
     "ts-node": "^10.2.1",
     "typescript": "^5.2.2",
     "vscode-test": "^1.6.1",
-    "webpack": "^5.75.0",
-    "webpack-cli": "^4.8.0"
+    "webpack": "^5.96.1",
+    "webpack-cli": "^5.1.4"
   },
   "dependencies": {
     "@sentry/cli": "^2.21.2",

--- a/src/download.ts
+++ b/src/download.ts
@@ -7,7 +7,7 @@ import { pipeline } from 'stream';
 import path from 'path';
 import * as vscode from 'vscode';
 
-export const minimum = '2.29.3';
+export const minimum = '3.0.0';
 
 export function getInstallPath(): string {
     if (os.platform() === 'win32') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
     
     context.subscriptions.push(vscode.commands.registerCommand('okteto.up', upCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.down', downCmd));
+    context.subscriptions.push(vscode.commands.registerCommand('okteto.test', testCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.install', installCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.deploy', deployCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.destroy', destroyCmd));
@@ -363,6 +364,34 @@ async function deployCmd() {
     } catch(err: any) {
         reporter.captureError(`okteto deploy failed: ${err.message}`, err);
         vscode.window.showErrorMessage(`Okteto: Deploy failed: ${err.message}`);
+    }
+}
+
+async function testCmd() {
+    try{
+        await checkPrereqs(true);
+    } catch(err: any) {   
+        vscode.window.showErrorMessage(err.message);    
+        return;
+    }
+    
+    const manifestUri = await showManifestPicker();
+    if (!manifestUri) {
+        reporter.track(events.manifestDismissed);
+        return;
+    }
+
+    reporter.track(events.manifestSelected);
+    const manifestPath = manifestUri.fsPath;
+    console.log(`user selected: ${manifestPath}`);
+
+    try {
+        var namespace = await getNamespace();
+        reporter.track(events.test);
+        await okteto.test(namespace, manifestPath);
+    } catch(err: any) {
+        reporter.captureError(`okteto test failed: ${err.message}`, err);
+        vscode.window.showErrorMessage(`Okteto: Test failed: ${err.message}`);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -586,6 +586,8 @@ async function showManifestTestPicker(tests: manifest.Test[]) : Promise<manifest
             test: t
         };
     });
+
+    items.push({label: "All tests", test: new manifest.Test("")})
     
     const testItem = await vscode.window.showQuickPick(items, {
         canPickMany: false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('okteto.up', upCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.down', downCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.install', installCmd));
-    context.subscriptions.push(vscode.commands.registerCommand('okteto.create', createCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.deploy', deployCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.destroy', destroyCmd));
     context.subscriptions.push(vscode.commands.registerCommand('okteto.context', contextCmd));
@@ -439,43 +438,6 @@ export function getDefaultLocationManifest(): vscode.Uri | undefined{
     const loc = vscode.Uri.file(p);
     console.log(`default location: ${loc.fsPath.toString()}`);
     return loc;
-}
-
-
-async function createCmd(){
-    try{
-        await checkPrereqs(true);
-    } catch(err: any) {   
-        vscode.window.showErrorMessage(err.message);    
-        return;
-    }
-
-    reporter.track(events.create);
-
-    const manifestUri = getDefaultLocationManifest();
-    if (!manifestUri) {
-        reporter.track(events.createFailed);
-        vscode.window.showErrorMessage(`Okteto: Create failed: Couldn't detect your project's path`);
-        return;
-    }
-
-    try {
-        await okteto.init(manifestUri);
-    } catch(err: any) {
-        reporter.track(events.oktetoInitFailed);
-        reporter.captureError(`okteto init failed: ${err.message}`, err);
-        vscode.window.showErrorMessage(`Okteto: Create failed: ${err}`);
-        return;
-    }
-
-    try {
-        await vscode.commands.executeCommand('vscode.openFolder', manifestUri.fsPath);
-    } catch (err: any) {
-        reporter.track(events.createOpenFailed);
-        reporter.captureError(`open folder failed ${err.message}`, err);
-        vscode.window.showErrorMessage(`Okteto: Create failed: Couldn't open ${manifestUri.fsPath}`);
-        return;
-    }
 }
 
 async function contextCmd(){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,6 +163,8 @@ async function upCmd() {
         serviceName = choice.name;
     }
     
+    let namespace = await getNamespace();
+
     let port = m.port;
     if (port === 0 || port === undefined) {
         try {
@@ -170,11 +172,9 @@ async function upCmd() {
         } catch(err: any) {
             reporter.track(events.sshPortFailed);
             reporter.captureError(`ssh.getPort failed: ${err.message}`, err);
-            return onOktetoFailed(`Okteto: Up failed to find an available port: ${err}`, `${ctx.namespace}-${m.name}`);
+            return onOktetoFailed(`Okteto: Up failed to find an available port: ${err}`, `${namespace}-${m.name}`);
         }
     }    
-
-    let namespace = await getNamespace();
 
     okteto.up(manifestPath, namespace, m.name, port, serviceName);
     activeManifest.set(manifestUri.fsPath, manifestUri);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -109,8 +109,6 @@ export function parseManifest(parsed: yaml.Document.Parsed): Manifest[] {
     
     if (isOktetoV2(manifest)) {
         return getV2Services(manifest);
-    } else if (isOktetoV1(manifest)) {
-        return getV1Service(manifest)
     } else if (isDockerCompose(manifest)) {
         return getComposeServices(manifest);
     } else {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -2,8 +2,16 @@ import {promises} from 'fs';
 import * as yaml from 'yaml';
 import * as vscode from 'vscode';
 
-export class Manifest {
+export class Service {
     constructor(public name: string, public workdir: string, public port: number) {}
+}
+
+export class Test {
+    constructor(public name: string) {}
+}
+
+export class Manifest {
+    constructor(public services: Array<Service>, public tests: Array<Test>) {}
 }
 
 function isDockerCompose(manifest: any): boolean {
@@ -17,7 +25,7 @@ function isDockerCompose(manifest: any): boolean {
     return false;
 }
 
-function getComposeServices(manifest: any): Manifest[] {
+function getComposeServices(manifest: any): Service[] {
 
     var volumes = new Map<string, boolean>();
     if (manifest.volumes) {
@@ -36,7 +44,7 @@ function getComposeServices(manifest: any): Manifest[] {
                 if (s.length == 2) {
                     // if the volume is declared, it's not used for sync
                     if (!volumes.has(s[0])) {
-                        result.push(new Manifest(k, s[1], 0));
+                        result.push(new Service(k, s[1], 0));
                     }        
                 }
             }
@@ -59,15 +67,19 @@ function isOktetoV2(manifest: any): boolean {
         return true;
     }
 
+    if (manifest.test) {
+        return true;
+    }
+
     return false;
 }
 
-function getV2Services(manifest: any): Manifest[] {
-    const result: Array<Manifest> = [];
+function getV2Services(manifest: any): Service[] {
+    const result: Array<Service> = [];
     for (var k in manifest.dev) {
         const svc = manifest.dev[k];
         const workdir = getWorkdir(svc);
-        const m = new Manifest(k, workdir, svc.remote);
+        const m = new Service(k, workdir, svc.remote);
         result.push(m);
     }
         
@@ -88,19 +100,43 @@ function getWorkdir(devBlock :any): string {
     return "";
 }
 
-export function parseManifest(parsed: yaml.Document.Parsed): Manifest[] {
+function getTests(manifest :any): Array<Test> {
+    const tests = Array<Test>();
+    if (manifest.test){
+        for (var t in manifest.test) {
+            tests.push(new Test(t));
+        }
+
+        tests.push(new Test("all"));
+    }
+
+    return tests
+}
+
+function parseV2Manifest(manifest: any): Manifest {
+    const services = getV2Services(manifest)
+    const tests = getTests(manifest)
+    return new Manifest(services, tests);
+}
+
+function parseComposeManifest(manifest: any): Manifest {
+    const services = getComposeServices(manifest)
+    return new Manifest(services, []);
+}
+
+export function parseManifest(parsed: yaml.Document.Parsed): Manifest  {
     const manifest = parsed.toJSON();
-    
+
     if (isOktetoV2(manifest)) {
-        return getV2Services(manifest);
+        return parseV2Manifest(manifest);
     } else if (isDockerCompose(manifest)) {
-        return getComposeServices(manifest);
+        return parseComposeManifest(manifest);
     } else {
-        return [];
+        return new Manifest([],[]);
     }
 }
 
-export async function getManifests(manifestPath: vscode.Uri): Promise<Manifest[]> {
+export async function get(manifestPath: vscode.Uri): Promise<Manifest> {
     const data = await promises.readFile(manifestPath.fsPath, {encoding: 'utf8'});
     if (!data) {
         throw new Error(`${manifestPath} is not a valid Okteto manifest`);
@@ -113,7 +149,7 @@ export async function getManifests(manifestPath: vscode.Uri): Promise<Manifest[]
     }
     
     const r = parseManifest(parsed);
-    if (r.length == 0) {
+    if (r.services.length == 0 && r.tests.length == 0) {
         throw new Error(`${manifestPath} is not a valid manifest`);
     }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -106,8 +106,6 @@ function getTests(manifest :any): Array<Test> {
         for (var t in manifest.test) {
             tests.push(new Test(t));
         }
-
-        tests.push(new Test("all"));
     }
 
     return tests

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,7 @@ import * as yaml from 'yaml';
 import * as vscode from 'vscode';
 
 export class Manifest {
-    constructor(public name: string, public namespace: string, public workdir: string, public port: number) {}
+    constructor(public name: string, public workdir: string, public port: number) {}
 }
 
 function isDockerCompose(manifest: any): boolean {
@@ -36,7 +36,7 @@ function getComposeServices(manifest: any): Manifest[] {
                 if (s.length == 2) {
                     // if the volume is declared, it's not used for sync
                     if (!volumes.has(s[0])) {
-                        result.push(new Manifest(k, '', s[1], 0));
+                        result.push(new Manifest(k, s[1], 0));
                     }        
                 }
             }
@@ -62,20 +62,12 @@ function isOktetoV2(manifest: any): boolean {
     return false;
 }
 
-function isOktetoV1(manifest: any): boolean {
-    if (manifest.name) {
-        return true;
-    }
-
-    return false;
-}
-
 function getV2Services(manifest: any): Manifest[] {
     const result: Array<Manifest> = [];
     for (var k in manifest.dev) {
         const svc = manifest.dev[k];
         const workdir = getWorkdir(svc);
-        const m = new Manifest(k, manifest.namespace, workdir, svc.remote);
+        const m = new Manifest(k, workdir, svc.remote);
         result.push(m);
     }
         
@@ -94,14 +86,6 @@ function getWorkdir(devBlock :any): string {
     }
 
     return "";
-}
-
-function getV1Service(manifest: any): Manifest[] {
-    const m = new Manifest(manifest.name, manifest.namespace, manifest.workdir, manifest.remote);
-        if (!m.name){
-            throw new Error(`Invalid manifest`);
-        }
-        return [m];
 }
 
 export function parseManifest(parsed: yaml.Document.Parsed): Manifest[] {

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -158,7 +158,7 @@ export async function install(progress: vscode.Progress<{increment: number, mess
   }
 }
 
-export function up(manifest: vscode.Uri, namespace: string, name: string, port: number, serviceName: string) {
+export function up(manifest: vscode.Uri, namespace: string, name: string, port: number) {
   console.log(`okteto up ${manifest.fsPath}`);
   disposeTerminal(`${terminalName}-${namespace}-${name}`);
   isActive.set(`${terminalName}-${namespace}-${name}`, false);
@@ -186,7 +186,7 @@ export function up(manifest: vscode.Uri, namespace: string, name: string, port: 
   }
 
   isActive.set(`${terminalName}-${namespace}-${name}`, true);
-  let cmd = `${binary} up ${serviceName} -f '${finalManifest}' --remote ${port}`;
+  let cmd = `${binary} up ${name} -f '${finalManifest}' --remote ${port}`;
 
   const config = vscode.workspace.getConfiguration('okteto');
   if (config) {
@@ -197,11 +197,11 @@ export function up(manifest: vscode.Uri, namespace: string, name: string, port: 
   term.sendText(cmd, true);
 }
 
-export async function down(manifest: vscode.Uri, namespace: string, name: string, serviceName: string) {
+export async function down(manifest: vscode.Uri, namespace: string, name: string) {
   isActive.set(`${terminalName}-${namespace}-${name}`, false);
   disposeTerminal(`${terminalName}-${namespace}-${name}`);
   
-  const r =  execa(getBinary(), ['down', serviceName, '--file', `${manifest.fsPath}`, '--namespace', `${namespace}`], {
+  const r =  execa(getBinary(), ['down', name, '--file', `${manifest.fsPath}`, '--namespace', `${namespace}`], {
     env: {
       "OKTETO_ORIGIN":"vscode"
     },
@@ -217,27 +217,6 @@ export async function down(manifest: vscode.Uri, namespace: string, name: string
   }
 
   console.log('okteto down completed');
-}
-
-export async function init(manifestPath: vscode.Uri) {    
-  const name = `${terminalName}-init`;
-  disposeTerminal(name);
-  isActive.set(name, false);
-
-  const term = vscode.window.createTerminal({
-    name: name,
-    hideFromUser: false,
-    env: {
-      "OKTETO_ORIGIN":"vscode",
-    },
-    iconPath: new vscode.ThemeIcon('server-process'),
-    cwd: path.dirname(manifestPath.fsPath)
-  });
-
-  isActive.set(name, true);
-  term.sendText(`${getBinary()} init --replace --file ${manifestPath.fsPath}`, true);
-  term.show(false);
-  console.log('okteto init completed');
 }
 
 export async function deploy(namespace: string, manifestPath: string) {
@@ -280,7 +259,7 @@ export async function destroy(namespace: string, manifestUri: vscode.Uri) {
   console.log('okteto destroy completed');
 }
 
-export async function test(namespace: string, manifestPath: string) {
+export async function test(namespace: string, manifestPath: string, test: string) {
   const name = `${terminalName}-${namespace}-test`;
   disposeTerminal(name);
   isActive.set(name, false);
@@ -295,7 +274,7 @@ export async function test(namespace: string, manifestPath: string) {
   });
 
   isActive.set(name, true);
-  term.sendText(`${getBinary()} test -f ${manifestPath}`, true);
+  term.sendText(`${getBinary()} test -f ${manifestPath} ${test}`, true);
   term.show(true);
   console.log('okteto test completed');
 }

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -280,6 +280,26 @@ export async function destroy(namespace: string, manifestUri: vscode.Uri) {
   console.log('okteto destroy completed');
 }
 
+export async function test(namespace: string, manifestPath: string) {
+  const name = `${terminalName}-${namespace}-test`;
+  disposeTerminal(name);
+  isActive.set(name, false);
+
+  const term = vscode.window.createTerminal({
+    name: name,
+    hideFromUser: false,
+    env: {
+      "OKTETO_ORIGIN":"vscode",
+    },
+    iconPath: new vscode.ThemeIcon('server-process')
+  });
+
+  isActive.set(name, true);
+  term.sendText(`${getBinary()} test -f ${manifestPath}`, true);
+  term.show(true);
+  console.log('okteto test completed');
+}
+
 export async function setContext(context: string) : Promise<boolean>{
   const name = `${terminalName}-context`;
   disposeTerminal(name);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -18,6 +18,7 @@ export const events = {
     createFinished: 'cmd_create_success',
     deploy: 'cmd_deploy',
     destroy: 'cmd_destroy',
+    test: 'cmd_test',
     down: 'cmd_down',
     downFinished: 'cmd_down_success',
     namespace: "cmd_namespace",

--- a/src/test/suite/artifacts/legacy-manifest.yaml
+++ b/src/test/suite/artifacts/legacy-manifest.yaml
@@ -1,9 +1,0 @@
-name: api
-namespace: test
-command: ["bash"]
-forward:
-- 8080:8080
-- 9229:9229
-sync:
-- api:/usr/src/app
-workdir: /usr/src/app

--- a/src/test/suite/artifacts/legacy-manifest.yaml
+++ b/src/test/suite/artifacts/legacy-manifest.yaml
@@ -1,0 +1,9 @@
+name: api
+namespace: test
+command: ["bash"]
+forward:
+- 8080:8080
+- 9229:9229
+sync:
+- api:/usr/src/app
+workdir: /usr/src/app

--- a/src/test/suite/artifacts/manifest-tests.yaml
+++ b/src/test/suite/artifacts/manifest-tests.yaml
@@ -1,0 +1,36 @@
+build:
+  api:
+    context: api
+  frontend:
+    context: frontend
+deploy:
+  - helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
+dev:
+  api:
+    command: ["bash"]
+    forward:
+      - 8080:8080
+      - 9229:9229
+    sync:
+      - api:/usr/src/app
+    workdir: /usr/src/app
+test:
+  api:
+    image: node:20
+    context: api
+    caches:
+      - yarn/.cache
+      - node_modules
+    commands:
+      - yarn install
+      - yarn test
+  frontend:
+    image: node:20
+    context: frontend
+    caches:
+      - yarn/.cache
+      - node_modules
+    commands:
+      - yarn install
+      - yarn test
+

--- a/src/test/suite/artifacts/manifest-with-compose.yaml
+++ b/src/test/suite/artifacts/manifest-with-compose.yaml
@@ -1,10 +1,5 @@
-build:
-  api:
-    context: api
-  frontend:
-    context: frontend
 deploy:
-  - helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
+  compose: docker-compose.yaml
 dev:
   api:
     command: ["bash"]

--- a/src/test/suite/artifacts/manifest-workdir.yaml
+++ b/src/test/suite/artifacts/manifest-workdir.yaml
@@ -5,7 +5,6 @@ build:
     context: frontend
 deploy:
   - helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}
-namespace: test
 dev:
   api:
     command: ["bash"]

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -3,7 +3,6 @@
 import * as manifest from '../../manifest';
 import * as yaml from 'yaml';
 import * as fs from 'fs';
-import path from 'path';
 import { expect } from 'chai';
 
 describe('parseManifest', () => {
@@ -15,8 +14,6 @@ describe('parseManifest', () => {
     expect(result.length).to.equal(2);
     expect(result[0].workdir).to.equal('/usr/src/app');
     expect(result[1].workdir).to.equal('/usr/src/frontend');
-    expect(result[0].namespace).to.equal('test');
-    expect(result[1].namespace).to.equal('test');
   });
 
   it('parse v2 manifest without workdir', () => {
@@ -29,8 +26,6 @@ describe('parseManifest', () => {
     expect(result[2].workdir).to.equal('');
     expect(result[3].workdir).to.equal('/usr/src/frontend');
     expect(result[4].workdir).to.equal('/usr/src/frontend');
-    expect(result[0].namespace).to.equal('test');
-    expect(result[1].namespace).to.equal('test');
   });
 
   it('parse docker-compose', () => {

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -37,7 +37,6 @@ describe('parseManifest', () => {
     expect(result.tests.length).to.equal(3);
     expect(result.tests[0].name).to.equal('api');
     expect(result.tests[1].name).to.equal('frontend');
-    expect(result.tests[2].name).to.equal('all');
   });
 
   it('parse docker-compose', () => {

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -10,52 +10,65 @@ describe('parseManifest', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/simple-manifest.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result).to.not.equal(undefined);
-    expect(result.length).to.equal(2);
-    expect(result[0].workdir).to.equal('/usr/src/app');
-    expect(result[1].workdir).to.equal('/usr/src/frontend');
+    expect(result.services.length).to.equal(2);
+    expect(result.tests.length).to.equal(0);
+    expect(result.services[0].workdir).to.equal('/usr/src/app');
+    expect(result.services[1].workdir).to.equal('/usr/src/frontend');
   });
 
   it('parse v2 manifest without workdir', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/manifest-workdir.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(5);
-    expect(result[0].workdir).to.equal('/usr/src/app');
-    expect(result[1].workdir).to.equal('/usr/src/frontend');
-    expect(result[2].workdir).to.equal('');
-    expect(result[3].workdir).to.equal('/usr/src/frontend');
-    expect(result[4].workdir).to.equal('/usr/src/frontend');
+    expect(result.services.length).to.equal(5);
+    expect(result.tests.length).to.equal(0);
+    expect(result.services[0].workdir).to.equal('/usr/src/app');
+    expect(result.services[1].workdir).to.equal('/usr/src/frontend');
+    expect(result.services[2].workdir).to.equal('');
+    expect(result.services[3].workdir).to.equal('/usr/src/frontend');
+    expect(result.services[4].workdir).to.equal('/usr/src/frontend');
+  });
+
+  it('parse v2 manifest with tests', () => {
+    const data = fs.readFileSync('src/test/suite/artifacts/manifest-tests.yaml', {encoding: 'utf8'});
+    const parsed = yaml.parseDocument(data);
+    const result = manifest.parseManifest(parsed);
+    expect(result.services.length).to.equal(1);
+    expect(result.tests.length).to.equal(3);
+    expect(result.tests[0].name).to.equal('api');
+    expect(result.tests[1].name).to.equal('frontend');
+    expect(result.tests[2].name).to.equal('all');
   });
 
   it('parse docker-compose', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/docker-compose.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(1);
-    expect(result[0].workdir).to.equal('/usr/src/app');
-    expect(result[0].name).to.equal('vote');
-    expect(result[0].port).to.equal(0);
+    expect(result.services.length).to.equal(1);
+    expect(result.tests.length).to.equal(0);
+    expect(result.services[0].workdir).to.equal('/usr/src/app');
+    expect(result.services[0].name).to.equal('vote');
+    expect(result.services[0].port).to.equal(0);
   });
 
   it('invalid docker-compose fails validation', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/docker-compose-invalid.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(0);
+    expect(result.services.length).to.equal(0);
   });
 
   it('valid docker-compose pases validation', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/docker-compose.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(1);
+    expect(result.services.length).to.equal(1);
   });
 
-  it('parse legacy manifest', () => {
+  it('parse legacy manifest fails validation', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/legacy-manifest.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(0);
+    expect(result.services.length).to.equal(0);
   });
 });

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -61,9 +61,6 @@ describe('parseManifest', () => {
     const data = fs.readFileSync('src/test/suite/artifacts/legacy-manifest.yaml', {encoding: 'utf8'});
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
-    expect(result.length).to.equal(1);
-    expect(result[0].name).to.equal('api');
-    expect(result[0].workdir).to.equal('/usr/src/app');
-    expect(result[0].namespace).to.equal('test');
+    expect(result.length).to.equal(0);
   });
 });

--- a/src/test/suite/manifest.test.ts
+++ b/src/test/suite/manifest.test.ts
@@ -34,7 +34,7 @@ describe('parseManifest', () => {
     const parsed = yaml.parseDocument(data);
     const result = manifest.parseManifest(parsed);
     expect(result.services.length).to.equal(1);
-    expect(result.tests.length).to.equal(3);
+    expect(result.tests.length).to.equal(2);
     expect(result.tests[0].name).to.equal('api');
     expect(result.tests[1].name).to.equal('frontend');
   });


### PR DESCRIPTION
Upgrades to support the CLI 3.0

1. Remove okteto init
2. Remote support for v1 manifests and stacks
3. Add support for 'okteto test' command