### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/okteto/remote-kubernetes/security/code-scanning/4](https://github.com/okteto/remote-kubernetes/security/code-scanning/4)

To correct the problem, explicitly declare the minimal permissions required for this workflow. In most cases, workflows that only check out code and perform analysis require only read access to repository contents. The best approach is to add a `permissions` key, as a direct child of the `analyze` job (after `runs-on:` or before `strategy:`) or at the workflow root (after `name:` and before `on:`). If you only want to affect the `analyze` job (and not add a root-level permissions block), add:
```yaml
permissions:
  contents: read
```
directly under the `analyze:` job (same indentation level as `runs-on`). No changes are required to any imports, and there is no need to install additional packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
