### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: publish-marketplace
+permissions:
+  contents: read
 on:
   release:
     types: 


### PR DESCRIPTION
Potential fix for [https://github.com/okteto/remote-kubernetes/security/code-scanning/3](https://github.com/okteto/remote-kubernetes/security/code-scanning/3)

The best way to fix this problem is by adding a `permissions` block to the workflow file. This can be done either at the top level (applies to all jobs) or per job. Since there is only one job in this workflow, it's simplest to add it at the top level, immediately below the `name:` or `on:` keys. 

The minimal starting point recommended by CodeQL is `contents: read`, which prevents unneeded write access by the GITHUB_TOKEN in the workflow. If the workflow requires additional permissions, such as `packages: write` or `pull-requests: write`, those can be added, but based on the steps shown, only reading from the repo and publishing to the marketplace/Sentry (with explicit tokens) are performed, so `contents: read` is sufficient.

**File to edit:**  
- `.github/workflows/publish.yml`

**Region to edit:**  
- Add a `permissions` block immediately after the workflow `name` and before the `on:` block.

**What needs to be implemented:**  
- Add `permissions` block with at least `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
