### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: CI/CD
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/okteto/remote-kubernetes/security/code-scanning/2](https://github.com/okteto/remote-kubernetes/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` key to the workflow, explicitly limiting the GITHUB_TOKEN's access to the minimum necessary. Since the workflow only needs to check out code and upload artifacts (which does not require write access to contents), `contents: read` is a safe, minimal, and recommended setting. This provides principle-of-least-privilege security without affecting existing functionality. The edit should be made at the root of the workflow file (`.github/workflows/nodejs.yml`), right after the workflow name and before the `on:` trigger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
