### PR TITLE
Fix telemetry lifecycle, add coverage, and bump Okteto CLI minimum to 3.17.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,7 @@
 name: "CodeQL"
 
 on:
-  pull_request:
-    # The branches below must be a subset of the branches above
+  push:
     branches: [ main ]
   schedule:
     - cron: '35 20 * * 6'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ out
 .vscode-test
 *.vsix
 smoke-test-screenshots
+.DS_Store
+.DS_STORE
+**/.DS_Store
+**/.DS_STORE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 ### Dependencies
 - Updated all dependencies to latest versions
 - Fixed security vulnerabilities
+- Updated minimum required Okteto CLI version to 3.17.0
+- Refreshed documentation references for minimum supported CLI version
 
 ## 0.5.4
 - Updated minimum required Okteto CLI version to 3.16.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The extension starts a development environment in your Kubernetes cluster by usi
 ## Requirements
 
 1. VS Code 1.88 or newer.
+1. Okteto CLI 3.17.0 or newer.
 1. Deploy access to a Kubernetes cluster.
 1. An OpenSSH compatible [SSH client](https://code.visualstudio.com/docs/remote/troubleshooting#_installing-a-supported-ssh-client) available in your workstation.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -140,6 +140,7 @@ Use this checklist before releasing a new version of the Remote - Kubernetes ext
 - [ ] Error message is user-friendly
 - [ ] Output panel shows helpful details
 - [ ] Restore Okteto CLI
+- [ ] Reinstall/restore Okteto CLI at version 3.17.0 or newer
 
 **Issues found:**
 ```

--- a/scripts/README_SMOKE_TEST.md
+++ b/scripts/README_SMOKE_TEST.md
@@ -15,7 +15,7 @@ The smoke test validates the core extension functionality by:
 ## Prerequisites
 
 - **macOS** (script designed for macOS, uses `screencapture`)
-- **Okteto CLI** installed and in PATH
+- **Okteto CLI 3.17.0+** installed and in PATH
 - **Logged into Okteto cluster** (`okteto context` should show active context)
 - **Node.js 22.x** and npm
 - **Git** installed
@@ -68,7 +68,7 @@ The smoke test validates the core extension functionality by:
 ==========================================
 
 [STEP] Checking prerequisites...
-[INFO] ✓ Okteto CLI found: okteto version 3.16.0
+[INFO] ✓ Okteto CLI found: okteto version 3.17.0
 [INFO] ✓ Logged into Okteto: https://cloud.okteto.com
 [INFO] ✓ Node.js found: v22.x.x
 [INFO] ✓ npm found: 10.x.x

--- a/src/download.ts
+++ b/src/download.ts
@@ -11,7 +11,7 @@ import { getLogger } from './logger';
 /**
  * Minimum required Okteto CLI version.
  */
-export const minimum = '3.16.0';
+export const minimum = '3.17.0';
 
 /**
  * Gets the platform-specific installation path for the Okteto CLI binary.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -524,6 +524,9 @@ async function contextCmd(){
 
     const machineId = okteto.getMachineId();
     const ctx = okteto.getContext();
+    if (reporter) {
+        reporter.dispose();
+    }
     reporter = new Reporter(getExtensionVersion(), ctx.id, machineId);
     reporter.track(events.activated);
 }
@@ -537,7 +540,34 @@ async function namespaceCmd(){
     }
 
     reporter.track(events.namespace);
-    const ns = await vscode.window.showInputBox({title: "Set the namespace for all the Okteto commands"})
+    const namespaceItems = await okteto.getNamespaceList();
+    const pickerItems: Array<vscode.QuickPickItem & { value: string }> = [...namespaceItems, {
+        label: "Enter namespace manually",
+        description: "Type a namespace name",
+        value: "manual",
+    }];
+
+    const selectedNamespace = await vscode.window.showQuickPick(pickerItems, {
+        canPickMany: false,
+        placeHolder: 'Select the namespace for all the Okteto commands',
+    });
+    if (!selectedNamespace) {
+        return;
+    }
+
+    let ns = selectedNamespace.value;
+    if (selectedNamespace.value === "manual") {
+        const customNamespace = await vscode.window.showInputBox({
+            title: "Set the namespace for all the Okteto commands",
+            prompt: "Specify a namespace name",
+        });
+        if (!customNamespace) {
+            return;
+        }
+
+        ns = customNamespace;
+    }
+
     if (!ns) {
         return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -565,6 +565,7 @@ async function namespaceCmd(){
             return;
         }
 
+        await okteto.createNamespace(customNamespace);
         ns = customNamespace;
     }
 

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -56,6 +56,15 @@ interface OktetoContextListItem {
   name: string;
 }
 
+/**
+ * Represents an individual namespace item from `okteto namespace list -o=json`.
+ */
+interface OktetoNamespaceListItem {
+  name?: string;
+  namespace?: string;
+  current?: boolean;
+}
+
 export const state = {
   starting: 'starting',
   activating: 'activating',
@@ -454,6 +463,27 @@ export async function setNamespace(namespace: string) {
 }
 
 /**
+ * Creates an Okteto namespace.
+ * Runs `okteto namespace create <namespace>`.
+ * @param namespace - Name of the namespace to create
+ * @returns Promise that resolves to true if the command succeeds
+ */
+export async function createNamespace(namespace: string): Promise<boolean> {
+  try {
+    const r = await execa(getBinary(), ['namespace', 'create', namespace], {
+      env: {
+        OKTETO_ORIGIN: 'vscode',
+      },
+    });
+
+    return !r.failed;
+  } catch (err: unknown) {
+    getLogger().error(`failed to create namespace ${namespace}: ${err}`);
+    throw err;
+  }
+}
+
+/**
  * Gets user-friendly state messages for Okteto operations.
  * Maps internal state codes to descriptive messages shown to users.
  * @returns Map of state codes to display messages
@@ -754,6 +784,53 @@ export async function getContextList(): Promise<RuntimeItem[]>{
   }
 
   items.push(new RuntimeItem("Create new context", "Create new context", "create"))
+  return items;
+}
+
+/**
+ * Gets the list of available Okteto namespaces.
+ * Runs `okteto namespace list -o=json` and parses the JSON output.
+ * @returns Array of namespace items for the quick pick dialog
+ */
+export async function getNamespaceList(): Promise<RuntimeItem[]>{
+  const items = new Array<RuntimeItem>();
+  const seen = new Set<string>();
+
+  try {
+    const r = await execa(getBinary(), ["namespace", "list", "-o=json"]);
+    const namespaceList = JSON.parse(r.stdout) as unknown;
+    if (Array.isArray(namespaceList)) {
+      for (const item of namespaceList) {
+        let namespace = "";
+        let description = "";
+
+        if (typeof item === 'string') {
+          namespace = item;
+        } else if (typeof item === 'object' && item !== null) {
+          const ns = item as OktetoNamespaceListItem;
+          if (typeof ns.name === 'string') {
+            namespace = ns.name;
+          } else if (typeof ns.namespace === 'string') {
+            namespace = ns.namespace;
+          }
+
+          if (ns.current === true) {
+            description = "Current namespace";
+          }
+        }
+
+        if (!namespace || seen.has(namespace)) {
+          continue;
+        }
+
+        seen.add(namespace);
+        items.push(new RuntimeItem(namespace, description, namespace));
+      }
+    }
+  } catch(err: unknown) {
+    getLogger().error(`failed to get namespace list: ${err}`);
+  }
+
   return items;
 }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -77,11 +77,12 @@ export class Reporter {
             this.enabled = false;
         }
 
-        // Listen for VS Code global telemetry changes
+        // Listen for VS Code global telemetry changes and re-evaluate effective state.
         this.telemetryListener = vscode.env.onDidChangeTelemetryEnabled((enabled) => {
-            if (!enabled) {
-                this.enabled = false;
-            }
+            const currentConfig = vscode.workspace.getConfiguration('okteto');
+            const extTelemetry = currentConfig.get<boolean>('telemetry');
+            const extEnabled = extTelemetry !== undefined ? extTelemetry : true;
+            this.enabled = enabled && extEnabled;
         });
 
         if (oktetoId) {

--- a/src/test/mock/vscode.ts
+++ b/src/test/mock/vscode.ts
@@ -4,10 +4,35 @@
  */
 import Module from 'module';
 
+const configuration: Record<string, Record<string, unknown>> = {};
+const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
+const telemetryListeners = new Set<(enabled: boolean) => void>();
+
+function getConfigValue(section: string, key: string): unknown {
+  return configuration[section]?.[key];
+}
+
+function setConfigValue(section: string, key: string, value: unknown): void {
+  if (!configuration[section]) {
+    configuration[section] = {};
+  }
+  configuration[section][key] = value;
+}
+
+function resetMockState(): void {
+  for (const section of Object.keys(configuration)) {
+    delete configuration[section];
+  }
+  registeredCommands.clear();
+  telemetryListeners.clear();
+  vscodeStub.workspace.workspaceFolders = [];
+  vscodeStub.env.isTelemetryEnabled = false;
+}
+
 const vscodeStub: Record<string, any> = {
   workspace: {
-    getConfiguration: () => ({
-      get: () => undefined,
+    getConfiguration: (section: string) => ({
+      get: (key: string) => getConfigValue(section, key),
     }),
     findFiles: async () => [],
     workspaceFolders: [],
@@ -39,8 +64,21 @@ const vscodeStub: Record<string, any> = {
     terminals: [],
   },
   commands: {
-    registerCommand: () => ({ dispose: () => {} }),
-    executeCommand: async () => undefined,
+    registerCommand: (command: string, callback: (...args: unknown[]) => unknown) => {
+      registeredCommands.set(command, callback);
+      return {
+        dispose: () => {
+          registeredCommands.delete(command);
+        },
+      };
+    },
+    executeCommand: async (command: string, ...args: unknown[]) => {
+      const callback = registeredCommands.get(command);
+      if (!callback) {
+        return undefined;
+      }
+      return callback(...args);
+    },
     getCommands: async () => [],
   },
   extensions: {
@@ -50,7 +88,14 @@ const vscodeStub: Record<string, any> = {
     machineId: 'test-machine-id',
     sessionId: 'test-session-id',
     isTelemetryEnabled: false,
-    onDidChangeTelemetryEnabled: () => ({ dispose: () => {} }),
+    onDidChangeTelemetryEnabled: (listener: (enabled: boolean) => void) => {
+      telemetryListeners.add(listener);
+      return {
+        dispose: () => {
+          telemetryListeners.delete(listener);
+        },
+      };
+    },
   },
   version: '1.109.0',
   Uri: {
@@ -67,6 +112,17 @@ const vscodeStub: Record<string, any> = {
     event = () => ({ dispose: () => {} });
     fire() {}
     dispose() {}
+  },
+  __mock: {
+    reset: () => resetMockState(),
+    setConfiguration: (section: string, key: string, value: unknown) => {
+      setConfigValue(section, key, value);
+    },
+    emitTelemetryEnabledChanged: (enabled: boolean) => {
+      vscodeStub.env.isTelemetryEnabled = enabled;
+      telemetryListeners.forEach((listener) => listener(enabled));
+    },
+    getRegisteredCommand: (command: string) => registeredCommands.get(command),
   },
 };
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -103,6 +103,7 @@ describe('namespace command', () => {
       { label: 'dev', description: 'Current namespace', value: 'dev' } as vscode.QuickPickItem & { value: string },
       { label: 'staging', description: '', value: 'staging' } as vscode.QuickPickItem & { value: string },
     ] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const createNamespace = sinon.stub(okteto, 'createNamespace').resolves(true);
     const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
 
     sinon.stub(vscode.window, 'showQuickPick').resolves(
@@ -114,6 +115,7 @@ describe('namespace command', () => {
     await vscode.commands.executeCommand('okteto.namespace');
 
     expect(setNamespace.calledOnceWithExactly('staging')).to.equal(true);
+    expect(createNamespace.called).to.equal(false);
     expect(showInputBox.called).to.equal(false);
   });
 
@@ -122,6 +124,7 @@ describe('namespace command', () => {
     sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
     sinon.stub(okteto, 'getMachineId').returns('machine-id');
     sinon.stub(okteto, 'getNamespaceList').resolves([] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const createNamespace = sinon.stub(okteto, 'createNamespace').resolves(true);
     const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
 
     sinon.stub(vscode.window, 'showQuickPick').resolves(
@@ -132,7 +135,9 @@ describe('namespace command', () => {
     activateExtension();
     await vscode.commands.executeCommand('okteto.namespace');
 
+    expect(createNamespace.calledOnceWithExactly('my-custom-namespace')).to.equal(true);
     expect(setNamespace.calledOnceWithExactly('my-custom-namespace')).to.equal(true);
+    sinon.assert.callOrder(createNamespace, setNamespace);
   });
 
   it('should not set namespace when picker is dismissed', async () => {
@@ -140,6 +145,7 @@ describe('namespace command', () => {
     sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
     sinon.stub(okteto, 'getMachineId').returns('machine-id');
     sinon.stub(okteto, 'getNamespaceList').resolves([] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const createNamespace = sinon.stub(okteto, 'createNamespace').resolves(true);
     const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
 
     sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
@@ -148,6 +154,7 @@ describe('namespace command', () => {
     activateExtension();
     await vscode.commands.executeCommand('okteto.namespace');
 
+    expect(createNamespace.called).to.equal(false);
     expect(setNamespace.called).to.equal(false);
     expect(showInputBox.called).to.equal(false);
   });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,0 +1,154 @@
+'use strict';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as telemetry from '../../telemetry';
+import * as okteto from '../../okteto';
+
+type MockVSCode = typeof vscode & {
+  __mock: {
+    reset: () => void;
+  };
+};
+
+interface ReporterCtor {
+  new (...args: unknown[]): {
+    track: (event: string) => Promise<void>;
+    captureError: (message: string, err: unknown) => void;
+    dispose: () => void;
+  };
+}
+
+interface MutableTelemetryModule {
+  Reporter: ReporterCtor;
+}
+
+function activateExtension() {
+  delete require.cache[require.resolve('../../extension')];
+  const extension = require('../../extension') as { activate: (ctx: { subscriptions: Array<{ dispose: () => void }> }) => void };
+  const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+  extension.activate(context);
+}
+
+describe('extension reporter lifecycle', () => {
+  const mockVSCode = vscode as unknown as MockVSCode;
+
+  beforeEach(() => {
+    mockVSCode.__mock.reset();
+    sinon.restore();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should dispose previous reporter when replacing it after context change', async () => {
+    const reporterInstances: Array<{ disposed: boolean }> = [];
+
+    const telemetryModule = telemetry as unknown as MutableTelemetryModule;
+    const originalReporter = telemetryModule.Reporter;
+    function FakeReporter(this: { disposed: boolean }) {
+      this.disposed = false;
+      reporterInstances.push(this);
+    }
+    (FakeReporter as unknown as ReporterCtor).prototype.track = async function () {};
+    (FakeReporter as unknown as ReporterCtor).prototype.captureError = function () {};
+    (FakeReporter as unknown as ReporterCtor).prototype.dispose = function () {
+      this.disposed = true;
+    };
+    telemetryModule.Reporter = FakeReporter as unknown as ReporterCtor;
+    try {
+      sinon.stub(okteto, 'needsInstall').resolves({ install: false, upgrade: false });
+      sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
+      sinon.stub(okteto, 'getMachineId').returns('machine-id');
+      sinon.stub(okteto, 'getContextList').resolves([] as unknown as Awaited<ReturnType<typeof okteto.getContextList>>);
+      sinon.stub(okteto, 'setContext').resolves(true);
+
+      sinon.stub(vscode.window, 'showQuickPick').resolves(
+        { value: 'ctx-name' } as vscode.QuickPickItem & { value: string },
+      );
+      sinon.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+
+      activateExtension();
+
+      await vscode.commands.executeCommand('okteto.context');
+
+      expect(reporterInstances.length).to.equal(2);
+      expect(reporterInstances[0].disposed).to.equal(true);
+      expect(reporterInstances[1].disposed).to.equal(false);
+    } finally {
+      telemetryModule.Reporter = originalReporter;
+    }
+  });
+});
+
+describe('namespace command', () => {
+  const mockVSCode = vscode as unknown as MockVSCode;
+
+  beforeEach(() => {
+    mockVSCode.__mock.reset();
+    sinon.restore();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should set namespace from quick pick selection', async () => {
+    sinon.stub(okteto, 'needsInstall').resolves({ install: false, upgrade: false });
+    sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
+    sinon.stub(okteto, 'getMachineId').returns('machine-id');
+    sinon.stub(okteto, 'getNamespaceList').resolves([
+      { label: 'dev', description: 'Current namespace', value: 'dev' } as vscode.QuickPickItem & { value: string },
+      { label: 'staging', description: '', value: 'staging' } as vscode.QuickPickItem & { value: string },
+    ] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
+
+    sinon.stub(vscode.window, 'showQuickPick').resolves(
+      { label: 'staging', description: '', value: 'staging' } as vscode.QuickPickItem & { value: string },
+    );
+    const showInputBox = sinon.stub(vscode.window, 'showInputBox').resolves('ignored');
+
+    activateExtension();
+    await vscode.commands.executeCommand('okteto.namespace');
+
+    expect(setNamespace.calledOnceWithExactly('staging')).to.equal(true);
+    expect(showInputBox.called).to.equal(false);
+  });
+
+  it('should allow entering namespace manually', async () => {
+    sinon.stub(okteto, 'needsInstall').resolves({ install: false, upgrade: false });
+    sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
+    sinon.stub(okteto, 'getMachineId').returns('machine-id');
+    sinon.stub(okteto, 'getNamespaceList').resolves([] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
+
+    sinon.stub(vscode.window, 'showQuickPick').resolves(
+      { label: 'Enter namespace manually', description: 'Type a namespace name', value: 'manual' } as vscode.QuickPickItem & { value: string },
+    );
+    sinon.stub(vscode.window, 'showInputBox').resolves('my-custom-namespace');
+
+    activateExtension();
+    await vscode.commands.executeCommand('okteto.namespace');
+
+    expect(setNamespace.calledOnceWithExactly('my-custom-namespace')).to.equal(true);
+  });
+
+  it('should not set namespace when picker is dismissed', async () => {
+    sinon.stub(okteto, 'needsInstall').resolves({ install: false, upgrade: false });
+    sinon.stub(okteto, 'getContext').returns({ id: 'ctx-id', name: 'ctx-name', namespace: 'ns', isOkteto: true });
+    sinon.stub(okteto, 'getMachineId').returns('machine-id');
+    sinon.stub(okteto, 'getNamespaceList').resolves([] as unknown as Awaited<ReturnType<typeof okteto.getNamespaceList>>);
+    const setNamespace = sinon.stub(okteto, 'setNamespace').resolves(true);
+
+    sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
+    const showInputBox = sinon.stub(vscode.window, 'showInputBox').resolves('ignored');
+
+    activateExtension();
+    await vscode.commands.executeCommand('okteto.namespace');
+
+    expect(setNamespace.called).to.equal(false);
+    expect(showInputBox.called).to.equal(false);
+  });
+});

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -2,6 +2,14 @@
 
 import { expect } from 'chai';
 import { events, Reporter } from '../../telemetry';
+import * as vscode from 'vscode';
+
+type MockVSCode = typeof vscode & {
+  __mock: {
+    reset: () => void;
+    emitTelemetryEnabledChanged: (enabled: boolean) => void;
+  };
+};
 
 describe('events', () => {
   it('should have all expected event names', () => {
@@ -27,6 +35,12 @@ describe('events', () => {
 });
 
 describe('Reporter', () => {
+  const mockVSCode = vscode as unknown as MockVSCode;
+
+  beforeEach(() => {
+    mockVSCode.__mock.reset();
+  });
+
   it('should be constructable', () => {
     // The vscode mock has isTelemetryEnabled = false, so telemetry is disabled
     const reporter = new Reporter('1.0.0', 'test-id', 'machine-id');
@@ -65,5 +79,32 @@ describe('Reporter', () => {
   it('should fall back to vscode.env.machineId when both are empty', async () => {
     const reporter = new Reporter('1.0.0', '', '');
     await reporter.track('test-event');
+  });
+
+  it('should disable and re-enable tracking on telemetry off->on transitions', async () => {
+    mockVSCode.__mock.emitTelemetryEnabledChanged(true);
+    const reporter = new Reporter('1.0.0', 'test-id', 'machine-id');
+
+    let tracked = 0;
+    const reporterWithMp = reporter as unknown as {
+      mp: { track: (event: string, props: unknown, callback: (err?: unknown) => void) => void };
+    };
+    reporterWithMp.mp = {
+      track: (_event: string, _props: unknown, callback: (err?: unknown) => void) => {
+        tracked++;
+        callback();
+      },
+    };
+
+    await reporter.track('before-disable');
+    expect(tracked).to.equal(1);
+
+    mockVSCode.__mock.emitTelemetryEnabledChanged(false);
+    await reporter.track('after-disable');
+    expect(tracked).to.equal(1);
+
+    mockVSCode.__mock.emitTelemetryEnabledChanged(true);
+    await reporter.track('after-re-enable');
+    expect(tracked).to.equal(2);
   });
 });


### PR DESCRIPTION
## Summary
- fix telemetry toggle handling so reporting can re-enable after VS Code telemetry is turned back on
- dispose the previous telemetry reporter before replacing it during context switches
- add explicit unit tests for telemetry off->on transition and reporter replacement disposal
- extend the VS Code test mock to support command registration/execution and telemetry change events
- bump minimum required Okteto CLI version to 3.17.0 and update related docs/changelog references
- remove and ignore macOS .DS_Store artifacts
- automatically load the list of available namespaces

## Validation
- npm test --silent -- --grep 'extension reporter lifecycle|disable and re-enable tracking on telemetry off->on transitions|Reporter|events'
- npm test --silent -- --grep 'minimum version|getOktetoDownloadInfo'
- npm run lint --silent (no errors; existing warnings only)

