### PR TITLE
Fix CodeQL CI: add security-events permission and workflow_dispatch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ on:
     branches: [ main ]
   schedule:
     - cron: '35 20 * * 6'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,8 +6,9 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v6
     - name: get tag

--- a/src/test/mock/vscode.ts
+++ b/src/test/mock/vscode.ts
@@ -9,6 +9,44 @@ const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
 const telemetryListeners = new Set<(enabled: boolean) => void>();
 const outputChannels: Array<{name: string; disposed: boolean; dispose: () => void}> = [];
 
+type ModuleInternals = typeof Module & {
+  _resolveFilename: (
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+    options: unknown,
+  ) => string;
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+
+type MockWorkspace = {
+  getConfiguration: (section: string) => { get: (key: string) => unknown };
+  findFiles: () => Promise<unknown[]>;
+  workspaceFolders: unknown[];
+};
+
+type MockEnv = {
+  machineId: string;
+  sessionId: string;
+  isTelemetryEnabled: boolean;
+  shell: string | undefined;
+  onDidChangeTelemetryEnabled: (listener: (enabled: boolean) => void) => { dispose: () => void };
+};
+
+type MockVscode = {
+  workspace: MockWorkspace;
+  window: Record<string, unknown> & { terminals: Array<{ name: string }> };
+  commands: Record<string, unknown>;
+  extensions: Record<string, unknown>;
+  env: MockEnv;
+  version: string;
+  Uri: Record<string, unknown>;
+  ThemeIcon: unknown;
+  ProgressLocation: Record<string, unknown>;
+  EventEmitter: unknown;
+  __mock: Record<string, unknown>;
+};
+
 function getConfigValue(section: string, key: string): unknown {
   return configuration[section]?.[key];
 }
@@ -32,7 +70,7 @@ function resetMockState(): void {
   vscodeStub.env.shell = undefined;
 }
 
-const vscodeStub: Record<string, any> = {
+const vscodeStub: MockVscode = {
   workspace: {
     getConfiguration: (section: string) => ({
       get: (key: string) => getConfigValue(section, key),
@@ -141,12 +179,13 @@ const vscodeStub: Record<string, any> = {
 };
 
 // Override Node's module resolution to intercept 'vscode' requires
-const originalResolveFilename = (Module as any)._resolveFilename;
-(Module as any)._resolveFilename = function (
+const moduleInternals = Module as ModuleInternals;
+const originalResolveFilename = moduleInternals._resolveFilename;
+moduleInternals._resolveFilename = function (
   request: string,
-  parent: any,
+  parent: unknown,
   isMain: boolean,
-  options: any,
+  options: unknown,
 ) {
   if (request === 'vscode') {
     // Return a sentinel that we intercept in _load
@@ -155,8 +194,8 @@ const originalResolveFilename = (Module as any)._resolveFilename;
   return originalResolveFilename.call(this, request, parent, isMain, options);
 };
 
-const originalLoad = (Module as any)._load;
-(Module as any)._load = function (request: string, parent: any, isMain: boolean) {
+const originalLoad = moduleInternals._load;
+moduleInternals._load = function (request: string, parent: unknown, isMain: boolean) {
   if (request === 'vscode') {
     return vscodeStub;
   }

--- a/src/test/smoke/smoke.test.ts
+++ b/src/test/smoke/smoke.test.ts
@@ -5,6 +5,21 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { execSync } from 'child_process';
 
+type ServicePickItem = {
+    label?: string;
+    service?: {
+        name?: string;
+    };
+};
+
+type MutableWindow = typeof vscode.window & {
+    showQuickPick: (
+        items: ServicePickItem[] | Thenable<ServicePickItem[]>,
+        options?: vscode.QuickPickOptions
+    ) => Promise<ServicePickItem | undefined>;
+    showInputBox: (options?: vscode.InputBoxOptions) => Promise<string | undefined>;
+};
+
 suite('Smoke Test Suite', function() {
     // Longer timeout for real Okteto operations
     this.timeout(10 * 60 * 1000); // 10 minutes
@@ -23,7 +38,10 @@ suite('Smoke Test Suite', function() {
         originalShowInputBox = vscode.window.showInputBox;
 
         // Stub showQuickPick to auto-select first option or specific ones
-        (vscode.window as any).showQuickPick = async function(items: any, options?: any): Promise<any> {
+        (vscode.window as MutableWindow).showQuickPick = async function(
+            items: ServicePickItem[] | Thenable<ServicePickItem[]>,
+            options?: vscode.QuickPickOptions
+        ): Promise<ServicePickItem | undefined> {
             const itemsArray = Array.isArray(items) ? items : await items;
 
             if (!itemsArray || itemsArray.length === 0) {
@@ -37,7 +55,7 @@ suite('Smoke Test Suite', function() {
                 return itemsArray[0];
             } else if (options?.placeHolder?.includes('service')) {
                 // Select catalog service
-                const catalogItem = itemsArray.find((item: any) =>
+                const catalogItem = itemsArray.find((item: ServicePickItem) =>
                     item.label === service || item.service?.name === service
                 );
                 console.log(`[SMOKE TEST] Auto-selecting service: ${service}`);
@@ -54,7 +72,9 @@ suite('Smoke Test Suite', function() {
         };
 
         // Stub showInputBox to provide predetermined values
-        (vscode.window as any).showInputBox = async function(_options?: any): Promise<string | undefined> {
+        (vscode.window as MutableWindow).showInputBox = async function(
+            _options?: vscode.InputBoxOptions
+        ): Promise<string | undefined> {
             console.log('[SMOKE TEST] Auto-providing input');
             return 'test-input';
         };
@@ -62,8 +82,8 @@ suite('Smoke Test Suite', function() {
 
     suiteTeardown(function() {
         // Restore original functions
-        (vscode.window as any).showQuickPick = originalShowQuickPick;
-        (vscode.window as any).showInputBox = originalShowInputBox;
+        (vscode.window as MutableWindow).showQuickPick = originalShowQuickPick as MutableWindow['showQuickPick'];
+        (vscode.window as MutableWindow).showInputBox = originalShowInputBox as MutableWindow['showInputBox'];
     });
 
     test('Full smoke test workflow', async function() {
@@ -177,7 +197,7 @@ suite('Smoke Test Suite', function() {
             const content = fs.readFileSync(stateFile, 'utf8').trim();
             const state = content.split(':')[0];
             return state || 'unknown';
-        } catch (error) {
+        } catch {
             // File doesn't exist yet or can't be read
             return 'starting';
         }

--- a/src/test/suite/machineid.test.ts
+++ b/src/test/suite/machineid.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 describe('hash', () => {
   it('should hash as in the CLI', () => {
-    const result = machineid.hash('C72838A8-E910-5811-96CC-2EE2FDC4FA82');
+    const result = machineid.hash('C72838A8-E910-5811-96CC-2EE2FDC4FA82'); // lgtm[js/hardcoded-credentials]
     expect(result).to.equal('ac37a66b09c84707cddfe45cbb8b207f28bc2514d8a483707f247a6109f7c741');
   });
 });


### PR DESCRIPTION
## Summary

- Add `security-events: write` to the CodeQL `analyze` job — the action was failing with a configuration error because it couldn't upload SARIF results without this permission
- Add explicit job-level `permissions: contents: read` to `nodejs.yml` and `publish.yml` build jobs to satisfy the `actions/missing-workflow-permissions` CodeQL alerts
- Add `workflow_dispatch` trigger to `codeql-analysis.yml` so the scan can be run manually from the Actions tab
- Suppress `js/hardcoded-credentials` false positive on the test fixture UUID in `machineid.test.ts`
- Fix `MockEnv` TypeScript type to include `shell` property; replace `any` casts with proper types in smoke tests

## Test plan

- [ ] Verify CodeQL workflow passes on this PR after merge to main
- [ ] Trigger the workflow manually from the Actions tab to confirm `workflow_dispatch` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)