### PR TITLE
Fix okteto.* commands failing on PowerShell with "Unexpected token"

### DIFF
--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -11,7 +11,7 @@ import * as semver from 'semver';
 import * as paths from './paths';
 import find from 'find-process';
 import { getLogger } from './logger';
-import { quote, detectShell, ShellKind } from './shell';
+import { quote, invokeBinary, detectShell, ShellKind } from './shell';
 import { getErrorMessage } from './errors';
 import { MtimeCache } from './cache';
 
@@ -1035,7 +1035,7 @@ export function buildUpCommand(opts: {
   shell: ShellKind;
 }): string {
   const { binary, name, manifest, port, extraArgs, shell } = opts;
-  let cmd = `${quote(binary, shell)} up ${quote(name, shell)} -f ${quote(manifest, shell)} --remote ${port}`;
+  let cmd = `${invokeBinary(binary, shell)} up ${quote(name, shell)} -f ${quote(manifest, shell)} --remote ${port}`;
   if (extraArgs) {
     cmd = `${cmd} ${extraArgs}`;
   }
@@ -1047,7 +1047,7 @@ export function buildUpCommand(opts: {
  */
 export function buildDeployCommand(opts: {binary: string; manifestPath: string; shell: ShellKind}): string {
   const { binary, manifestPath, shell } = opts;
-  return `${quote(binary, shell)} deploy -f ${quote(manifestPath, shell)} --wait`;
+  return `${invokeBinary(binary, shell)} deploy -f ${quote(manifestPath, shell)} --wait`;
 }
 
 /**
@@ -1055,7 +1055,7 @@ export function buildDeployCommand(opts: {binary: string; manifestPath: string; 
  */
 export function buildDestroyCommand(opts: {binary: string; manifestPath: string; shell: ShellKind}): string {
   const { binary, manifestPath, shell } = opts;
-  return `${quote(binary, shell)} destroy -f ${quote(manifestPath, shell)}`;
+  return `${invokeBinary(binary, shell)} destroy -f ${quote(manifestPath, shell)}`;
 }
 
 /**
@@ -1064,7 +1064,7 @@ export function buildDestroyCommand(opts: {binary: string; manifestPath: string;
 export function buildTestCommand(opts: {binary: string; manifestPath: string; test: string; shell: ShellKind}): string {
   const { binary, manifestPath, test, shell } = opts;
   const testArg = test ? ` ${quote(test, shell)}` : '';
-  return `${quote(binary, shell)} test -f ${quote(manifestPath, shell)}${testArg}`;
+  return `${invokeBinary(binary, shell)} test -f ${quote(manifestPath, shell)}${testArg}`;
 }
 
 /**
@@ -1072,7 +1072,7 @@ export function buildTestCommand(opts: {binary: string; manifestPath: string; te
  */
 export function buildSetContextCommand(opts: {binary: string; context: string; shell: ShellKind}): string {
   const { binary, context, shell } = opts;
-  return `${quote(binary, shell)} context use ${quote(context, shell)}`;
+  return `${invokeBinary(binary, shell)} context use ${quote(context, shell)}`;
 }
 
 /**
@@ -1080,7 +1080,7 @@ export function buildSetContextCommand(opts: {binary: string; context: string; s
  */
 export function buildSetNamespaceCommand(opts: {binary: string; namespace: string; shell: ShellKind}): string {
   const { binary, namespace, shell } = opts;
-  return `${quote(binary, shell)} namespace use ${quote(namespace, shell)}`;
+  return `${invokeBinary(binary, shell)} namespace use ${quote(namespace, shell)}`;
 }
 
 function extractMessage(error :string):string {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -96,6 +96,26 @@ export function quoteCmd(value: string): string {
 }
 
 /**
+ * Builds the leading `<binary>` portion of a shell command line: a quoted
+ * binary path, plus the call operator `&` on PowerShell.
+ *
+ * On PowerShell, a string literal at the start of a statement is parsed as
+ * a string expression rather than a command, so `'C:\path\okteto.exe' up …`
+ * fails with `Unexpected token 'up' in expression or statement`. The call
+ * operator forces invocation while keeping stdout/stderr attached to the
+ * current host (issue #341).
+ *
+ * POSIX shells treat a leading `&` as the background operator, and cmd.exe
+ * runs `"path" arg` without any prefix, so neither needs `&`.
+ *
+ * Reference: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators#call-operator-
+ */
+export function invokeBinary(binary: string, shell: ShellKind): string {
+    const quoted = quote(binary, shell);
+    return shell === 'powershell' ? `& ${quoted}` : quoted;
+}
+
+/**
  * Backwards-compatible alias for `quotePosix`. Prefer `quote(value, shell)`
  * with an explicit shell when adding new call sites.
  */

--- a/src/test/suite/okteto.commands.test.ts
+++ b/src/test/suite/okteto.commands.test.ts
@@ -99,7 +99,7 @@ describe('buildUpCommand', () => {
         );
     });
 
-    it('Windows + PowerShell: wraps Windows paths in single quotes, preserves backslashes', () => {
+    it('Windows + PowerShell: prefixes the call operator and wraps paths in single quotes (issue #341)', () => {
         const cmd = buildUpCommand({
             binary: psBinary,
             name: 'api',
@@ -108,7 +108,7 @@ describe('buildUpCommand', () => {
             shell: 'powershell',
         });
         expect(cmd).to.equal(
-            `'C:\\Program Files\\okteto\\okteto.exe' up 'api' -f 'C:\\Users\\Bob\\My Code\\okteto.yml' --remote 22105`,
+            `& 'C:\\Program Files\\okteto\\okteto.exe' up 'api' -f 'C:\\Users\\Bob\\My Code\\okteto.yml' --remote 22105`,
         );
     });
 
@@ -121,7 +121,7 @@ describe('buildUpCommand', () => {
             shell: 'powershell',
         });
         expect(cmd).to.equal(
-            `'C:\\Program Files\\okteto\\okteto.exe' up 'o''reilly' -f 'C:\\okteto.yml' --remote 22106`,
+            `& 'C:\\Program Files\\okteto\\okteto.exe' up 'o''reilly' -f 'C:\\okteto.yml' --remote 22106`,
         );
     });
 
@@ -192,6 +192,12 @@ describe('buildUpCommand', () => {
             });
             // The metacharacters must appear inside the same quoted region as the value.
             expect(cmd).to.match(/up [`'"]; rm -rf \/[`'"]/);
+            // PowerShell command lines must always start with the call operator
+            // so a maliciously-named binary can't drop the prefix and turn the
+            // line into a string-expression-then-statement parse.
+            if (shell === 'powershell') {
+                expect(cmd.startsWith(`& '`)).to.equal(true);
+            }
         }
     });
 });
@@ -206,13 +212,13 @@ describe('buildDeployCommand', () => {
         expect(cmd).to.equal(`'/home/user/.okteto-vscode/okteto' deploy -f '/home/user/okteto.yml' --wait`);
     });
 
-    it('powershell: handles Windows paths with spaces', () => {
+    it('powershell: prefixes the call operator and handles Windows paths with spaces (issue #341)', () => {
         const cmd = buildDeployCommand({
             binary: psBinary,
             manifestPath: 'C:\\My Projects\\app\\okteto.yml',
             shell: 'powershell',
         });
-        expect(cmd).to.equal(`'C:\\Program Files\\okteto\\okteto.exe' deploy -f 'C:\\My Projects\\app\\okteto.yml' --wait`);
+        expect(cmd).to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe' deploy -f 'C:\\My Projects\\app\\okteto.yml' --wait`);
     });
 
     it('cmd: handles Windows paths with spaces', () => {
@@ -252,12 +258,12 @@ describe('buildDestroyCommand', () => {
         })).to.equal(`'/home/user/.okteto-vscode/okteto' destroy -f '/home/user/okteto.yml'`);
     });
 
-    it('powershell with spaces', () => {
+    it('powershell with spaces (issue #341)', () => {
         expect(buildDestroyCommand({
             binary: psBinary,
             manifestPath: 'C:\\My Projects\\okteto.yml',
             shell: 'powershell',
-        })).to.equal(`'C:\\Program Files\\okteto\\okteto.exe' destroy -f 'C:\\My Projects\\okteto.yml'`);
+        })).to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe' destroy -f 'C:\\My Projects\\okteto.yml'`);
     });
 
     it('cmd with spaces', () => {
@@ -290,14 +296,14 @@ describe('buildTestCommand', () => {
         expect(cmd).to.equal(`'/home/user/.okteto-vscode/okteto' test -f '/home/user/okteto.yml'`);
     });
 
-    it('powershell: handles a test name with a hyphen', () => {
+    it('powershell: handles a test name with a hyphen (issue #341)', () => {
         const cmd = buildTestCommand({
             binary: psBinary,
             manifestPath: 'C:\\okteto.yml',
             test: 'integration-tests',
             shell: 'powershell',
         });
-        expect(cmd).to.equal(`'C:\\Program Files\\okteto\\okteto.exe' test -f 'C:\\okteto.yml' 'integration-tests'`);
+        expect(cmd).to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe' test -f 'C:\\okteto.yml' 'integration-tests'`);
     });
 
     it('cmd: handles a test name with spaces', () => {
@@ -321,13 +327,13 @@ describe('buildSetContextCommand', () => {
         expect(cmd).to.equal(`'/home/user/.okteto-vscode/okteto' context use 'https://okteto.example.com'`);
     });
 
-    it('powershell: handles a context with a hyphen', () => {
+    it('powershell: handles a context with a hyphen (issue #341)', () => {
         const cmd = buildSetContextCommand({
             binary: psBinary,
             context: 'my-kube-context',
             shell: 'powershell',
         });
-        expect(cmd).to.equal(`'C:\\Program Files\\okteto\\okteto.exe' context use 'my-kube-context'`);
+        expect(cmd).to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe' context use 'my-kube-context'`);
     });
 
     it('cmd: handles a Kubernetes context name with spaces', () => {
@@ -349,12 +355,12 @@ describe('buildSetNamespaceCommand', () => {
         })).to.equal(`'/home/user/.okteto-vscode/okteto' namespace use 'dev'`);
     });
 
-    it('powershell with hyphen', () => {
+    it('powershell with hyphen (issue #341)', () => {
         expect(buildSetNamespaceCommand({
             binary: psBinary,
             namespace: 'team-platform',
             shell: 'powershell',
-        })).to.equal(`'C:\\Program Files\\okteto\\okteto.exe' namespace use 'team-platform'`);
+        })).to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe' namespace use 'team-platform'`);
     });
 
     it('cmd', () => {
@@ -364,4 +370,52 @@ describe('buildSetNamespaceCommand', () => {
             shell: 'cmd',
         })).to.equal(`"C:\\Users\\Bob\\AppData\\Local\\Programs\\okteto.exe" namespace use "staging"`);
     });
+});
+
+describe('PowerShell call operator (issue #341)', () => {
+    // Cross-builder guardrail: every PowerShell command line must start with
+    // `& '` so a future builder added without invokeBinary fails CI here. A
+    // bare `'C:\…\okteto.exe' up …` line is parsed by PowerShell as a string
+    // expression followed by an unexpected statement.
+    const cases: Array<[string, () => string]> = [
+        ['buildUpCommand', () => buildUpCommand({
+            binary: psBinary,
+            name: 'api',
+            manifest: 'C:\\okteto.yml',
+            port: 22000,
+            shell: 'powershell',
+        })],
+        ['buildDeployCommand', () => buildDeployCommand({
+            binary: psBinary,
+            manifestPath: 'C:\\okteto.yml',
+            shell: 'powershell',
+        })],
+        ['buildDestroyCommand', () => buildDestroyCommand({
+            binary: psBinary,
+            manifestPath: 'C:\\okteto.yml',
+            shell: 'powershell',
+        })],
+        ['buildTestCommand', () => buildTestCommand({
+            binary: psBinary,
+            manifestPath: 'C:\\okteto.yml',
+            test: 'unit',
+            shell: 'powershell',
+        })],
+        ['buildSetContextCommand', () => buildSetContextCommand({
+            binary: psBinary,
+            context: 'my-context',
+            shell: 'powershell',
+        })],
+        ['buildSetNamespaceCommand', () => buildSetNamespaceCommand({
+            binary: psBinary,
+            namespace: 'dev',
+            shell: 'powershell',
+        })],
+    ];
+
+    for (const [name, run] of cases) {
+        it(`${name} starts with the call operator`, () => {
+            expect(run()).to.match(/^& '/);
+        });
+    }
 });

--- a/src/test/suite/shell.test.ts
+++ b/src/test/suite/shell.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import {
     detectShell,
+    invokeBinary,
     posixQuote,
     quote,
     quoteCmd,
@@ -178,6 +179,50 @@ describe('quote', () => {
 
         it('leaves single quotes alone (they are literal in cmd anyway)', () => {
             expect(quote(`it's`, 'cmd')).to.equal(`"it's"`);
+        });
+    });
+});
+
+describe('invokeBinary', () => {
+    describe('posix', () => {
+        it('quotes a bare binary name with no prefix', () => {
+            expect(invokeBinary('okteto', 'posix')).to.equal(`'okteto'`);
+        });
+
+        it('quotes an absolute path with no prefix', () => {
+            expect(invokeBinary('/usr/local/bin/okteto', 'posix')).to.equal(`'/usr/local/bin/okteto'`);
+        });
+
+        it('quotes a path with spaces with no prefix', () => {
+            expect(invokeBinary('/Users/Bob/My Tools/okteto', 'posix')).to.equal(`'/Users/Bob/My Tools/okteto'`);
+        });
+    });
+
+    describe('powershell (issue #341)', () => {
+        it('prefixes a bare binary name with the call operator', () => {
+            // PowerShell parses 'okteto' as a string expression, not a command — & forces invocation.
+            expect(invokeBinary('okteto', 'powershell')).to.equal(`& 'okteto'`);
+        });
+
+        it('prefixes an absolute Windows path with the call operator', () => {
+            expect(invokeBinary('C:\\Program Files\\okteto\\okteto.exe', 'powershell'))
+                .to.equal(`& 'C:\\Program Files\\okteto\\okteto.exe'`);
+        });
+
+        it('escapes embedded single quotes via doubling and still prefixes with &', () => {
+            expect(invokeBinary("C:\\Tom's Tools\\okteto.exe", 'powershell'))
+                .to.equal(`& 'C:\\Tom''s Tools\\okteto.exe'`);
+        });
+    });
+
+    describe('cmd', () => {
+        it('wraps a bare binary in double quotes with no prefix', () => {
+            expect(invokeBinary('okteto', 'cmd')).to.equal(`"okteto"`);
+        });
+
+        it('wraps a Windows path with spaces in double quotes with no prefix', () => {
+            expect(invokeBinary('C:\\Program Files\\okteto\\okteto.exe', 'cmd'))
+                .to.equal(`"C:\\Program Files\\okteto\\okteto.exe"`);
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #341 — every `Okteto:` command fails on PowerShell with `Unexpected token '<subcommand>' in expression or statement` after #318.

## Root cause

PR #318 introduced shell-aware quoting in `src/shell.ts`. For `shell === 'powershell'`, `quote()` wraps values in single quotes, so the six command builders in `src/okteto.ts` produced lines that begin with a quoted string literal:

```
'C:\Program Files\okteto\okteto.exe' up 'api' -f 'C:\…\okteto.yml' --remote 22000
```

PowerShell parses a leading single-quoted token as a *string expression*, not a command, so the next token (`up`) is a parse error.

## Fix

The canonical PowerShell idiom for invoking an executable whose path needs quoting is the **call operator** `&`. It forces invocation while keeping stdout/stderr attached to the integrated terminal (unlike `Start-Process`) and does not re-parse arguments (unlike `Invoke-Expression`, which would also reopen a quoting/injection footgun against `quotePowerShell`).

- New `invokeBinary(binary, shell)` helper in `src/shell.ts` that prepends `& ` only when `shell === 'powershell'`.
- All six builders in `src/okteto.ts` (`buildUpCommand`, `buildDeployCommand`, `buildDestroyCommand`, `buildTestCommand`, `buildSetContextCommand`, `buildSetNamespaceCommand`) now route the binary through `invokeBinary` instead of `quote`.
- POSIX (where `&` is the background operator) and `cmd.exe` (where `"path" arg` already invokes) are unchanged. Git Bash continues to use POSIX quoting via `gitBashMode()`.
- Works identically on Windows PowerShell 5.1 and PowerShell 7+ (`pwsh`).

## Test coverage

Unit tests grow from 165 → 240 in this PR (the bulk of the increase is unrelated coverage that landed in `pnpm test` collection; **+14** are this PR's: 8 new `invokeBinary` tests + 6 cross-builder regression tests):

- New `describe('invokeBinary', …)` block in `src/test/suite/shell.test.ts` covering POSIX, PowerShell, and cmd × bare names, paths with spaces, embedded apostrophes.
- Updated PowerShell expectations across all six builders in `src/test/suite/okteto.commands.test.ts` to expect the leading `& `.
- Tightened the existing metacharacter regression to assert `startsWith("& '")` for PowerShell so a malicious binary path can't drop the prefix.
- New `describe('PowerShell call operator (issue #341)', …)` cross-builder guardrail that asserts every PowerShell builder output matches `/^& '/`. Any future builder added without `invokeBinary` will fail CI here.

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `pnpm test` — 240 passing
- [x] `pnpm run test:e2e` — 10 passing
- [x] `pnpm run package` — produces `remote-kubernetes-0.5.4.vsix`
- [ ] Manual smoke on Windows: `Okteto: Up`, `Deploy`, `Destroy`, `Test`, `Set Context`, `Set Namespace` in a PowerShell-backed VS Code terminal (PS 5.1 + PS 7), with a binary path that contains spaces (`C:\Program Files\okteto\okteto.exe`)
- [ ] Manual smoke on `cmd.exe` and Git Bash (`okteto.gitBash = true`) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)